### PR TITLE
emit close event and fix small formatting error

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "1tp",
-  "version": "0.5.0",
+  "version": "0.5.1",
   "description": "One transport protocol to rule them all -- offering a net-like stream API on top of various communication protocols",
   "main": "index.js",
   "keywords": [

--- a/src/net.js
+++ b/src/net.js
@@ -263,7 +263,8 @@ Socket.prototype.isConnected = function () {
 Socket.prototype.destroy = function () {
   var errorMsg = 'socket.destroy function not yet implemented'
   this._log.error(errorMsg)
-// this._error(errorMsg)
+  // this._error(errorMsg)
+  this.emit('close')
 }
 
 Socket.prototype.end = function () {
@@ -285,7 +286,7 @@ var createServer = function () {
   var connectionListener = arguments[arguments.length - 1]
   // create new server instance
   var options = {
-    transports: transports,
+    transports: transports
   }
   return new Server(transports, connectionListener)
 }


### PR DESCRIPTION
This is needed to cleanly handle timeout/error/end events in mm-platform.

when each of those are received, the destroy() method is called. Event handlers are disconnected and stream is deleted once close event is received.